### PR TITLE
[Fix] Create the instance of OptionsControl after initializing PH

### DIFF
--- a/WPFFrontend/MainWindow.xaml.cs
+++ b/WPFFrontend/MainWindow.xaml.cs
@@ -25,11 +25,12 @@ namespace WPFFrontend
         ObservableCollection<BGEntity> EnemyTextEntries { get; set; }
 
         private MouseHook _mouseHook;
+        private bool _toShowEnemyList = true;
+
         private readonly object _stocksLock = new();
         private readonly ProcessHacker _processHacker = new();
         private readonly ConcurrentDictionary<int, EnemyControl> _currentEnemyControls = new();
-        private readonly OptionsControl _options = new();
-        private bool _toShowEnemyList = true;
+        private readonly OptionsControl _options;
 
         internal void deleteEnemyControlByTag(int tag)
         {
@@ -45,7 +46,9 @@ namespace WPFFrontend
             _processHacker.ProcessHooked += ProcessHacker_ProcessHooked;
 
             _processHacker.Init();
-            
+
+            _options = new();
+
             updateStyles();
 
             MainGrid.Children.Add(_options);   


### PR DESCRIPTION
This pull request fixes an oversight introduced in one of my previous PR. The creation of `OptionsControl` requires successful initialization of the `Configuration` object which is initialized in the `ProcessHacker.Init` method.

The creation of the object has been moved into constructor after calling `_processHacker.Init`.